### PR TITLE
Fix byte-compile warning

### DIFF
--- a/rigid-tabs.el
+++ b/rigid-tabs.el
@@ -48,8 +48,7 @@
 
 ;;; Code:
 
-(eval-when-compile
-  (require 'diff-mode))
+(require 'diff-mode)
 
 (defvar-local rigid-tabs-shift-chars 0)
 


### PR DESCRIPTION
Remove eval-when-compile, because this package uses function of diff-mode.

There is following byte-compile warning. This patch fixes it.

```
rigid-tabs.el:148:1:Warning: the function `diff-hunk-style' might not be
    defined at runtime.
```
